### PR TITLE
feat(portfolio): add token list filter and sort functionality for EVM portfolio

### DIFF
--- a/common/mokoresources/src/commonMain/moko-resources/base/strings.xml
+++ b/common/mokoresources/src/commonMain/moko-resources/base/strings.xml
@@ -1299,6 +1299,18 @@
     <string name="label_24h">24h</string>
     <string name="content_description_clear">Clear</string>
 
+    <!--    EVM Filter & Sort -->
+    <string name="label_filter_and_sort">Filter &amp; Sort</string>
+    <string name="label_hide_small_balances">Hide small balances (&lt; $1)</string>
+    <string name="label_sort_by">Sort By</string>
+    <string name="label_sort_by_name">Name</string>
+    <string name="label_sort_by_value">Value</string>
+    <string name="label_view_mode">View Mode</string>
+    <string name="label_view_mode_single_account">Single Account</string>
+    <string name="label_view_mode_all_accounts">All Accounts</string>
+    <string name="label_allocation">Allocation</string>
+    <string name="label_portfolio">Portfolio</string>
+
     <!--    Network Selection Bottom Sheet -->
     <string name="label_testnet">Testnet</string>
 </resources>

--- a/common/mokoresources/src/commonMain/moko-resources/vi/strings.xml
+++ b/common/mokoresources/src/commonMain/moko-resources/vi/strings.xml
@@ -1127,6 +1127,18 @@
     <string name="label_24h">24h</string>
     <string name="content_description_clear">Xóa</string>
 
+    <!--    EVM Filter & Sort -->
+    <string name="label_filter_and_sort">Lọc &amp; Sắp xếp</string>
+    <string name="label_hide_small_balances">Ẩn số dư nhỏ (&lt; $1)</string>
+    <string name="label_sort_by">Sắp xếp theo</string>
+    <string name="label_sort_by_name">Tên</string>
+    <string name="label_sort_by_value">Giá trị</string>
+    <string name="label_view_mode">Chế độ xem</string>
+    <string name="label_view_mode_single_account">Tài khoản đơn</string>
+    <string name="label_view_mode_all_accounts">Tất cả tài khoản</string>
+    <string name="label_allocation">Phân bổ</string>
+    <string name="label_portfolio">Danh mục</string>
+
     <!--    Network Selection Bottom Sheet -->
     <string name="label_testnet">Mạng thử nghiệm</string>
 </resources>

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletScreenModel.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletScreenModel.kt
@@ -1,6 +1,8 @@
 package com.mangala.features.wallet.presentationv2.evm
 
 import cafe.adriel.voyager.core.model.screenModelScope
+import com.mangala.features.wallet.presentationv2.evm.model.EVMFilterOptions
+import com.mangala.features.wallet.presentationv2.evm.model.EVMViewMode
 import com.mangala.wallet.model.blockchain.NetworkType
 import com.mangala.features.wallet.presentationv2.core.base.BaseWalletViewModel
 import com.mangala.wallet.domain.currency.usecases.GetCurrentCurrencyCodeUseCase
@@ -234,6 +236,12 @@ class EVMWalletScreenModel(
     fun onSearchQueryChanged(query: String) {
         _uiState.update { state ->
             state.copy(searchQuery = query)
+        }
+    }
+
+    fun onFilterOptionsChanged(filterOptions: EVMFilterOptions) {
+        _uiState.update { state ->
+            state.copy(filterOptions = filterOptions)
         }
     }
 }

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletScreenV2.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletScreenV2.kt
@@ -42,6 +42,7 @@ import com.mangala.features.wallet.presentationv2.core.base.BaseWalletScreenV2
 import com.mangala.features.wallet.presentationv2.core.common.components.WalletHeaderV2
 import com.mangala.features.wallet.presentationv2.evm.components.EVMAccountSwitchBottomSheet
 import com.mangala.features.wallet.presentationv2.evm.components.EVMAddAccountBottomSheet
+import com.mangala.features.wallet.presentationv2.evm.components.EVMFilterBottomSheet
 import com.mangala.features.wallet.presentationv2.evm.components.EVMPortfolioHeader
 import com.mangala.features.wallet.presentationv2.evm.components.EVMQuickActionsRow
 import com.mangala.features.wallet.presentationv2.evm.components.EVMTokenListSection
@@ -90,6 +91,7 @@ class EVMWalletScreenV2 : BaseWalletScreenV2<EVMWalletScreenModel>() {
             var showAddAccountBottomSheet by remember { mutableStateOf(false) }
             var showAccountSwitchBottomSheet by remember { mutableStateOf(false) }
             var showNetworkSelectionBottomSheet by remember { mutableStateOf(false) }
+            var showFilterBottomSheet by remember { mutableStateOf(false) }
 
             LaunchedEffect(Unit) {
                 delay(100)
@@ -181,7 +183,9 @@ class EVMWalletScreenV2 : BaseWalletScreenV2<EVMWalletScreenModel>() {
                                         )
                                         globalNavigator.push(screen)
                                     },
-                                    onHistoryClick = { },
+                                    onHistoryClick = {
+                                        globalNavigator.push(ScreenRegistry.get(SharedScreen.ContactListScreen))
+                                    },
                                     onScanClick = {
                                         val networkType = uiState.selectedNetwork?.blockchainType?.networkType
                                         networkType?.let {
@@ -218,14 +222,18 @@ class EVMWalletScreenV2 : BaseWalletScreenV2<EVMWalletScreenModel>() {
                                 )
                             ) {
                                 EVMTokenListSection(
-                                    tokens = uiState.activeAccount?.balances,
+                                    tokens = if (uiState.isAllAccountsView) null else uiState.filteredActiveAccountTokens,
                                     isBalanceHidden = uiState.isPortfolioBalanceHidden,
                                     isLoading = uiState.isLoadingWallets,
                                     currencySymbol = uiState.fiatSymbol,
                                     isSearchActive = uiState.isSearchActive,
                                     searchQuery = uiState.searchQuery,
+                                    isAllAccountsView = uiState.isAllAccountsView,
+                                    aggregatedTokens = uiState.filteredAggregatedTokens,
+                                    hasActiveFilters = uiState.hasActiveFilters,
                                     onSearchClick = { screenModel.onSearchToggled() },
                                     onSearchQueryChanged = { screenModel.onSearchQueryChanged(it) },
+                                    onFilterClick = { showFilterBottomSheet = true },
                                     onTokenClick = { }
                                 )
                             }
@@ -283,6 +291,14 @@ class EVMWalletScreenV2 : BaseWalletScreenV2<EVMWalletScreenModel>() {
                         showNetworkSelectionBottomSheet = false
                     },
                     onDismiss = { showNetworkSelectionBottomSheet = false }
+                )
+            }
+
+            if (showFilterBottomSheet) {
+                EVMFilterBottomSheet(
+                    currentOptions = uiState.filterOptions,
+                    onFilterOptionsChanged = screenModel::onFilterOptionsChanged,
+                    onDismiss = { showFilterBottomSheet = false }
                 )
             }
         } else {

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletUiState.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletUiState.kt
@@ -4,6 +4,11 @@ import androidx.compose.ui.graphics.Color
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import com.ionspin.kotlin.bignum.decimal.DecimalMode
 import com.ionspin.kotlin.bignum.decimal.RoundingMode
+import com.mangala.features.wallet.presentationv2.evm.model.EVMAggregatedToken
+import com.mangala.features.wallet.presentationv2.evm.model.EVMFilterOptions
+import com.mangala.features.wallet.presentationv2.evm.model.EVMTokenSortBy
+import com.mangala.features.wallet.presentationv2.evm.model.EVMViewMode
+import com.mangala.features.wallet.presentationv2.evm.model.toAggregatedTokens
 import com.mangala.wallet.model.blockchain.BlockchainNetworkData
 import com.mangala.wallet.ui.WalletThemeV2
 import com.mangala.wallet.model.token.domain.TokenBalanceModel
@@ -34,6 +39,8 @@ data class EVMWalletUiState(
     // Search state
     val isSearchActive: Boolean = false,
     val searchQuery: String = "",
+    // Filter state
+    val filterOptions: EVMFilterOptions = EVMFilterOptions(),
 ) {
     val hasWallet: Boolean = accounts.isNotEmpty() || isLoadingWallets
 
@@ -69,6 +76,78 @@ data class EVMWalletUiState(
                 else -> WalletThemeV2.Colors.negativeLoss
             }
         }
+
+    val isAllAccountsView: Boolean = filterOptions.viewMode == EVMViewMode.ALL_ACCOUNTS
+
+    val hasActiveFilters: Boolean
+        get() {
+            val defaults = EVMFilterOptions()
+            return filterOptions.hideSmallBalances != defaults.hideSmallBalances ||
+                    filterOptions.sortBy != defaults.sortBy
+        }
+
+    val filteredActiveAccountTokens: List<TokenBalanceModel>?
+        get() {
+            val tokens = activeAccount?.balances ?: return null
+            return filterAndSortTokens(tokens)
+        }
+
+    val aggregatedTokens: List<EVMAggregatedToken>
+        get() = accounts.toAggregatedTokens()
+
+    val filteredAggregatedTokens: List<EVMAggregatedToken>
+        get() = filterAndSortAggregatedTokens(aggregatedTokens)
+
+    private fun filterAndSortTokens(tokens: List<TokenBalanceModel>): List<TokenBalanceModel> {
+        val searched = if (searchQuery.isNotBlank()) {
+            tokens.filter { token ->
+                token.contractSymbol.contains(searchQuery, ignoreCase = true) ||
+                        token.contractName.contains(searchQuery, ignoreCase = true)
+            }
+        } else {
+            tokens
+        }
+
+        val filtered = searched.filter { token ->
+            if (token.isCoin) return@filter true
+            if (filterOptions.hideSmallBalances) {
+                val usdValue = token.todaysValue ?: BigDecimal.ZERO
+                if (usdValue < BigDecimal.ONE) return@filter false
+            }
+            true
+        }
+
+        return when (filterOptions.sortBy) {
+            EVMTokenSortBy.NAME -> filtered.sortedBy { it.contractSymbol.lowercase() }
+            EVMTokenSortBy.VALUE -> filtered.sortedByDescending { it.todaysValue ?: BigDecimal.ZERO }
+        }
+    }
+
+    private fun filterAndSortAggregatedTokens(
+        tokens: List<EVMAggregatedToken>
+    ): List<EVMAggregatedToken> {
+        val searched = if (searchQuery.isNotBlank()) {
+            tokens.filter { token ->
+                token.contractSymbol.contains(searchQuery, ignoreCase = true) ||
+                        token.contractName.contains(searchQuery, ignoreCase = true)
+            }
+        } else {
+            tokens
+        }
+
+        val filtered = searched.filter { token ->
+            if (token.isCoin) return@filter true
+            if (filterOptions.hideSmallBalances) {
+                if (token.totalValueUsd < BigDecimal.ONE) return@filter false
+            }
+            true
+        }
+
+        return when (filterOptions.sortBy) {
+            EVMTokenSortBy.NAME -> filtered.sortedBy { it.contractSymbol.lowercase() }
+            EVMTokenSortBy.VALUE -> filtered.sortedByDescending { it.totalValueUsd }
+        }
+    }
 }
 
 /**

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/components/EVMFilterBottomSheet.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/components/EVMFilterBottomSheet.kt
@@ -1,0 +1,284 @@
+package com.mangala.features.wallet.presentationv2.evm.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.mangala.features.wallet.presentationv2.evm.model.EVMFilterOptions
+import com.mangala.features.wallet.presentationv2.evm.model.EVMTokenSortBy
+import com.mangala.features.wallet.presentationv2.evm.model.EVMViewMode
+import com.mangala.wallet.common.mokoresources.font.getInterFontFamily
+import com.mangala.wallet.mokoresources.MR
+import com.mangala.wallet.ui.WalletThemeV2
+import dev.icerock.moko.resources.compose.stringResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EVMFilterBottomSheet(
+    currentOptions: EVMFilterOptions,
+    onFilterOptionsChanged: (EVMFilterOptions) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val bottomSheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = bottomSheetState,
+        containerColor = WalletThemeV2.Colors.cardBackground,
+        contentColor = Color.White,
+        dragHandle = {
+            Box(
+                modifier = Modifier
+                    .padding(vertical = 8.dp)
+                    .width(40.dp)
+                    .height(4.dp)
+                    .background(
+                        Color.White.copy(alpha = 0.3f),
+                        RoundedCornerShape(2.dp)
+                    )
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 32.dp)
+        ) {
+            Text(
+                text = stringResource(MR.strings.label_filter_and_sort),
+                fontSize = 20.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = WalletThemeV2.Colors.primaryText,
+                fontFamily = getInterFontFamily(),
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)
+            )
+
+            EVMFilterToggleItem(
+                title = stringResource(MR.strings.label_hide_small_balances),
+                isSelected = currentOptions.hideSmallBalances,
+                onClick = {
+                    onFilterOptionsChanged(
+                        currentOptions.copy(hideSmallBalances = !currentOptions.hideSmallBalances)
+                    )
+                }
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(MR.strings.label_sort_by),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium,
+                color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f),
+                fontFamily = getInterFontFamily(),
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+            )
+
+            EVMFilterSelectableItem(
+                title = stringResource(MR.strings.label_sort_by_name),
+                isSelected = currentOptions.sortBy == EVMTokenSortBy.NAME,
+                onClick = {
+                    onFilterOptionsChanged(currentOptions.copy(sortBy = EVMTokenSortBy.NAME))
+                }
+            )
+
+            EVMFilterSelectableItem(
+                title = stringResource(MR.strings.label_sort_by_value),
+                isSelected = currentOptions.sortBy == EVMTokenSortBy.VALUE,
+                onClick = {
+                    onFilterOptionsChanged(currentOptions.copy(sortBy = EVMTokenSortBy.VALUE))
+                }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = stringResource(MR.strings.label_view_mode),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium,
+                color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f),
+                fontFamily = getInterFontFamily(),
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+            )
+
+            EVMFilterSelectableItem(
+                title = stringResource(MR.strings.label_view_mode_single_account),
+                isSelected = currentOptions.viewMode == EVMViewMode.SINGLE_ACCOUNT,
+                onClick = {
+                    onFilterOptionsChanged(
+                        currentOptions.copy(viewMode = EVMViewMode.SINGLE_ACCOUNT)
+                    )
+                }
+            )
+
+            EVMFilterSelectableItem(
+                title = stringResource(MR.strings.label_view_mode_all_accounts),
+                isSelected = currentOptions.viewMode == EVMViewMode.ALL_ACCOUNTS,
+                onClick = {
+                    onFilterOptionsChanged(
+                        currentOptions.copy(viewMode = EVMViewMode.ALL_ACCOUNTS)
+                    )
+                }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun EVMFilterToggleItem(
+    title: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(Color.Transparent)
+            .border(
+                width = 1.dp,
+                brush = Brush.linearGradient(
+                    colors = listOf(
+                        Color(0xFF2A3E6C),
+                        Color(0xFF2A3E6C)
+                    )
+                ),
+                shape = RoundedCornerShape(16.dp)
+            )
+            .clickable { onClick() }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = title,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium,
+                color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f),
+                fontFamily = getInterFontFamily()
+            )
+
+            if (isSelected) {
+                Box(
+                    modifier = Modifier
+                        .size(20.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(WalletThemeV2.Colors.evmAccent),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Check,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(12.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EVMFilterSelectableItem(
+    title: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(Color.Transparent)
+            .border(
+                width = if (isSelected) 2.dp else 1.dp,
+                brush = if (isSelected) {
+                    Brush.linearGradient(
+                        colors = listOf(
+                            Color(0xFF3B90FF),
+                            Color(0xFFC27DFF)
+                        )
+                    )
+                } else {
+                    Brush.linearGradient(
+                        colors = listOf(
+                            Color(0xFF2A3E6C),
+                            Color(0xFF2A3E6C)
+                        )
+                    )
+                },
+                shape = RoundedCornerShape(16.dp)
+            )
+            .clickable { onClick() }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = title,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium,
+                color = WalletThemeV2.Colors.primaryText.copy(
+                    alpha = if (isSelected) 0.95f else 0.8f
+                ),
+                fontFamily = getInterFontFamily()
+            )
+
+            if (isSelected) {
+                Box(
+                    modifier = Modifier
+                        .size(20.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(WalletThemeV2.Colors.evmAccent),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Check,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(12.dp)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/components/EVMTokenListSection.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/components/EVMTokenListSection.kt
@@ -1,5 +1,11 @@
 package com.mangala.features.wallet.presentationv2.evm.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -8,6 +14,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -26,21 +33,29 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import com.mangala.features.wallet.presentationv2.antelope.components.TokenLogo
+import com.mangala.features.wallet.presentationv2.evm.model.EVMAggregatedToken
+import com.mangala.features.wallet.presentationv2.evm.model.EVMTokenAccountBreakdown
 import com.mangala.wallet.common.mokoresources.font.getInterFontFamily
 import com.mangala.wallet.common.mokoresources.icons.MangalaWalletPack
+import com.mangala.wallet.common.mokoresources.icons.mangalawalletpack.Filter
 import com.mangala.wallet.common.mokoresources.icons.mangalawalletpack.Search
 import com.mangala.wallet.model.token.domain.TokenBalanceModel
 import com.mangala.wallet.model.token.domain.formattedBalanceForHuman
@@ -50,6 +65,7 @@ import com.mangala.wallet.ui.HIDDEN_BALANCE_STRING
 import com.mangala.wallet.ui.WalletThemeV2
 import com.mangala.wallet.ui.imageloader.ImageSource
 import com.mangala.wallet.ui.placeholder.mangalaWalletPlaceholder
+import com.mangala.wallet.utils.ext.formatFiat
 import dev.icerock.moko.resources.compose.stringResource
 
 private fun Modifier.tokenListCard(): Modifier = this
@@ -81,29 +97,25 @@ fun EVMTokenListSection(
     currencySymbol: String,
     isSearchActive: Boolean = false,
     searchQuery: String = "",
+    isAllAccountsView: Boolean = false,
+    aggregatedTokens: List<EVMAggregatedToken> = emptyList(),
+    hasActiveFilters: Boolean = false,
     onSearchClick: () -> Unit = {},
     onSearchQueryChanged: (String) -> Unit = {},
+    onFilterClick: () -> Unit = {},
     onTokenClick: (TokenBalanceModel) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
-    val filteredTokens = remember(tokens, searchQuery) {
-        if (searchQuery.isBlank()) {
-            tokens
-        } else {
-            tokens?.filter { token ->
-                token.contractSymbol.contains(searchQuery, ignoreCase = true) ||
-                        token.contractName.contains(searchQuery, ignoreCase = true)
-            }
-        }
-    }
-
     val noTokensMatchMessage = stringResource(MR.strings.message_no_tokens_match, searchQuery)
     val noTokensFoundMessage = stringResource(MR.strings.message_no_tokens_found)
 
     Column(modifier = modifier.fillMaxWidth()) {
         TokenListHeader(
             isSearchActive = isSearchActive,
-            onSearchClick = onSearchClick
+            isAllAccountsView = isAllAccountsView,
+            hasActiveFilters = hasActiveFilters,
+            onSearchClick = onSearchClick,
+            onFilterClick = onFilterClick
         )
 
         if (isSearchActive) {
@@ -116,24 +128,46 @@ fun EVMTokenListSection(
 
         Spacer(modifier = Modifier.height(WalletThemeV2.Dimensions.spacingMedium))
 
-        when {
-            isLoading && filteredTokens.isNullOrEmpty() -> {
-                TokenListSkeleton()
-            }
+        if (isAllAccountsView) {
+            when {
+                isLoading && aggregatedTokens.isEmpty() -> {
+                    TokenListSkeleton()
+                }
 
-            filteredTokens.isNullOrEmpty() -> {
-                EmptyTokenState(
-                    message = if (searchQuery.isNotEmpty()) noTokensMatchMessage else noTokensFoundMessage
-                )
-            }
+                aggregatedTokens.isEmpty() -> {
+                    EmptyTokenState(
+                        message = if (searchQuery.isNotEmpty()) noTokensMatchMessage else noTokensFoundMessage
+                    )
+                }
 
-            else -> {
-                TokenListContent(
-                    tokens = filteredTokens,
-                    isBalanceHidden = isBalanceHidden,
-                    currencySymbol = currencySymbol,
-                    onTokenClick = onTokenClick
-                )
+                else -> {
+                    AggregatedTokenListContent(
+                        tokens = aggregatedTokens,
+                        isBalanceHidden = isBalanceHidden,
+                        currencySymbol = currencySymbol
+                    )
+                }
+            }
+        } else {
+            when {
+                isLoading && tokens.isNullOrEmpty() -> {
+                    TokenListSkeleton()
+                }
+
+                tokens.isNullOrEmpty() -> {
+                    EmptyTokenState(
+                        message = if (searchQuery.isNotEmpty()) noTokensMatchMessage else noTokensFoundMessage
+                    )
+                }
+
+                else -> {
+                    TokenListContent(
+                        tokens = tokens,
+                        isBalanceHidden = isBalanceHidden,
+                        currencySymbol = currencySymbol,
+                        onTokenClick = onTokenClick
+                    )
+                }
             }
         }
     }
@@ -142,10 +176,14 @@ fun EVMTokenListSection(
 @Composable
 private fun TokenListHeader(
     isSearchActive: Boolean,
-    onSearchClick: () -> Unit
+    isAllAccountsView: Boolean,
+    hasActiveFilters: Boolean,
+    onSearchClick: () -> Unit,
+    onFilterClick: () -> Unit
 ) {
     val tokensLabel = stringResource(MR.strings.label_tokens)
     val searchLabel = stringResource(MR.strings.label_search)
+    val filterLabel = stringResource(MR.strings.label_filter_and_sort)
 
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -153,21 +191,46 @@ private fun TokenListHeader(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = tokensLabel,
+            text = if (isAllAccountsView) stringResource(MR.strings.label_portfolio) else tokensLabel,
             fontSize = 16.sp,
             fontWeight = FontWeight.Medium,
             color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f),
             fontFamily = getInterFontFamily()
         )
 
-        Icon(
-            imageVector = MangalaWalletPack.Search,
-            contentDescription = searchLabel,
-            tint = if (isSearchActive) WalletThemeV2.Colors.evmAccent else WalletThemeV2.Colors.secondaryText,
-            modifier = Modifier
-                .size(WalletThemeV2.Dimensions.iconSizeMedium)
-                .clickable { onSearchClick() }
-        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            Icon(
+                imageVector = MangalaWalletPack.Search,
+                contentDescription = searchLabel,
+                tint = if (isSearchActive) WalletThemeV2.Colors.evmAccent else WalletThemeV2.Colors.secondaryText,
+                modifier = Modifier
+                    .size(WalletThemeV2.Dimensions.iconSizeMedium)
+                    .clickable { onSearchClick() }
+            )
+
+            Box {
+                Icon(
+                    imageVector = MangalaWalletPack.Filter,
+                    contentDescription = filterLabel,
+                    tint = if (hasActiveFilters) WalletThemeV2.Colors.evmAccent else WalletThemeV2.Colors.secondaryText,
+                    modifier = Modifier
+                        .size(WalletThemeV2.Dimensions.iconSizeMedium)
+                        .clickable { onFilterClick() }
+                )
+
+                if (hasActiveFilters) {
+                    Box(
+                        modifier = Modifier
+                            .size(6.dp)
+                            .clip(CircleShape)
+                            .background(WalletThemeV2.Colors.evmAccent)
+                            .align(Alignment.TopEnd)
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -253,6 +316,260 @@ private fun TokenListContent(
                     TokenListDivider()
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun AggregatedTokenListContent(
+    tokens: List<EVMAggregatedToken>,
+    isBalanceHidden: Boolean,
+    currencySymbol: String
+) {
+    Box(modifier = Modifier.tokenListCard()) {
+        Column {
+            tokens.forEachIndexed { index, token ->
+                EVMAggregatedTokenItem(
+                    token = token,
+                    isBalanceHidden = isBalanceHidden,
+                    currencySymbol = currencySymbol
+                )
+
+                if (index < tokens.lastIndex) {
+                    TokenListDivider()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EVMAggregatedTokenItem(
+    token: EVMAggregatedToken,
+    isBalanceHidden: Boolean,
+    currencySymbol: String,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    val pnlPercentage = remember(token.priceChangePercentage24h) {
+        token.priceChangePercentage24h?.let {
+            runCatching { BigDecimal.parseString(it) }.getOrNull()
+        }
+    }
+
+    val pnlColor = remember(pnlPercentage) {
+        when {
+            pnlPercentage == null -> WalletThemeV2.Colors.secondaryText
+            pnlPercentage > BigDecimal.ZERO -> WalletThemeV2.Colors.positiveGain
+            pnlPercentage < BigDecimal.ZERO -> WalletThemeV2.Colors.negativeLoss
+            else -> WalletThemeV2.Colors.secondaryText
+        }
+    }
+
+    val label24h = stringResource(MR.strings.label_24h)
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(Color.Transparent)
+                .clickable { expanded = !expanded }
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = WalletThemeV2.Dimensions.paddingLarge,
+                        vertical = WalletThemeV2.Dimensions.paddingMedium
+                    ),
+                verticalAlignment = Alignment.Top
+            ) {
+                Box(
+                    modifier = Modifier.size(24.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    TokenLogo(
+                        iconResource = token.logoUrl.takeIf { it.isNotEmpty() }
+                            ?.let { ImageSource.Url(it) },
+                        symbol = token.contractSymbol,
+                        size = 22.dp
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(WalletThemeV2.Dimensions.spacingMedium))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = token.contractSymbol,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.9f),
+                        fontFamily = getInterFontFamily()
+                    )
+
+                    Text(
+                        text = token.contractName,
+                        fontSize = 12.sp,
+                        color = WalletThemeV2.Colors.secondaryText,
+                        fontFamily = getInterFontFamily(),
+                        maxLines = 1
+                    )
+
+                    Text(
+                        text = label24h,
+                        fontSize = 10.sp,
+                        color = WalletThemeV2.Colors.tertiaryText,
+                        fontFamily = getInterFontFamily()
+                    )
+                }
+
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        text = if (isBalanceHidden) HIDDEN_BALANCE_STRING
+                        else token.totalBalance.scale(4).toStringExpanded(),
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.9f),
+                        fontFamily = getInterFontFamily()
+                    )
+
+                    Text(
+                        text = if (isBalanceHidden) HIDDEN_BALANCE_STRING
+                        else token.totalValueUsd.formatFiat(currencySymbol, decimalPlaces = 2),
+                        fontSize = 12.sp,
+                        color = WalletThemeV2.Colors.secondaryText,
+                        fontFamily = getInterFontFamily()
+                    )
+
+                    Text(
+                        text = formatPnlPercentage(pnlPercentage, isBalanceHidden),
+                        fontSize = 10.sp,
+                        color = if (isBalanceHidden) WalletThemeV2.Colors.secondaryText else pnlColor,
+                        fontFamily = getInterFontFamily()
+                    )
+                }
+            }
+        }
+
+        AnimatedVisibility(
+            visible = expanded,
+            enter = expandVertically() + fadeIn(),
+            exit = shrinkVertically() + fadeOut()
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        start = WalletThemeV2.Dimensions.paddingLarge + 24.dp + WalletThemeV2.Dimensions.spacingMedium,
+                        end = WalletThemeV2.Dimensions.paddingLarge,
+                        bottom = WalletThemeV2.Dimensions.paddingSmall
+                    )
+            ) {
+                Text(
+                    text = stringResource(MR.strings.label_allocation),
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = WalletThemeV2.Colors.tertiaryText,
+                    fontFamily = getInterFontFamily(),
+                    modifier = Modifier.padding(bottom = 6.dp)
+                )
+
+                token.accountBreakdown.forEachIndexed { index, breakdown ->
+                    AccountAllocationRow(
+                        breakdown = breakdown,
+                        isBalanceHidden = isBalanceHidden,
+                        currencySymbol = currencySymbol,
+                        isPrimaryAccount = index == 0
+                    )
+
+                    if (index < token.accountBreakdown.lastIndex) {
+                        Spacer(modifier = Modifier.height(4.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccountAllocationRow(
+    breakdown: EVMTokenAccountBreakdown,
+    isBalanceHidden: Boolean,
+    currencySymbol: String,
+    isPrimaryAccount: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val indicatorColor = if (isPrimaryAccount) {
+        WalletThemeV2.Colors.evmAccent
+    } else {
+        WalletThemeV2.Colors.secondaryText.copy(alpha = 0.6f)
+    }
+
+    val percentageText = remember(breakdown.percentage) {
+        "${(breakdown.percentage * 100).toInt()}%"
+    }
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier.size(32.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                drawArc(
+                    color = indicatorColor.copy(alpha = 0.2f),
+                    startAngle = 0f,
+                    sweepAngle = 360f,
+                    useCenter = false,
+                    style = Stroke(width = 3.dp.toPx(), cap = StrokeCap.Round)
+                )
+                drawArc(
+                    color = indicatorColor,
+                    startAngle = -90f,
+                    sweepAngle = 360f * breakdown.percentage,
+                    useCenter = false,
+                    style = Stroke(width = 3.dp.toPx(), cap = StrokeCap.Round)
+                )
+            }
+            Text(
+                text = percentageText,
+                fontSize = 8.sp,
+                fontWeight = FontWeight.Medium,
+                color = indicatorColor,
+                fontFamily = getInterFontFamily()
+            )
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Text(
+            text = breakdown.accountName,
+            fontSize = 12.sp,
+            color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f),
+            fontFamily = getInterFontFamily(),
+            modifier = Modifier.weight(1f)
+        )
+
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text = if (isBalanceHidden) HIDDEN_BALANCE_STRING
+                else breakdown.balance.scale(4).toStringExpanded(),
+                fontSize = 12.sp,
+                color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f),
+                fontFamily = getInterFontFamily()
+            )
+
+            Text(
+                text = if (isBalanceHidden) HIDDEN_BALANCE_STRING
+                else breakdown.valueUsd.formatFiat(currencySymbol, decimalPlaces = 2),
+                fontSize = 10.sp,
+                color = WalletThemeV2.Colors.secondaryText,
+                fontFamily = getInterFontFamily()
+            )
         }
     }
 }

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/model/EVMAggregatedToken.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/model/EVMAggregatedToken.kt
@@ -1,0 +1,104 @@
+package com.mangala.features.wallet.presentationv2.evm.model
+
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import com.ionspin.kotlin.bignum.decimal.DecimalMode
+import com.ionspin.kotlin.bignum.decimal.RoundingMode
+import com.mangala.features.wallet.presentationv2.evm.EVMAccountInfo
+import com.mangala.wallet.model.token.domain.TokenBalanceModel
+import com.mangala.wallet.utils.calculatingDecimalMode
+
+data class EVMAggregatedToken(
+    val contractAddress: String,
+    val contractSymbol: String,
+    val contractName: String,
+    val logoUrl: String,
+    val contractDecimals: Long,
+    val totalBalance: BigDecimal,
+    val totalValueUsd: BigDecimal,
+    val priceChangePercentage24h: String?,
+    val currentPrice: String?,
+    val isCoin: Boolean,
+    val accountBreakdown: List<EVMTokenAccountBreakdown>
+)
+
+data class EVMTokenAccountBreakdown(
+    val accountName: String,
+    val accountAddress: String,
+    val balance: BigDecimal,
+    val valueUsd: BigDecimal,
+    val percentage: Float
+)
+
+fun List<EVMAccountInfo>.toAggregatedTokens(): List<EVMAggregatedToken> {
+    data class TokenEntry(
+        val accountName: String,
+        val accountAddress: String,
+        val token: TokenBalanceModel
+    )
+
+    val allEntries = this.flatMap { account ->
+        (account.balances ?: emptyList()).map { token ->
+            TokenEntry(
+                accountName = account.accountName,
+                accountAddress = account.address,
+                token = token
+            )
+        }
+    }
+
+    val grouped = allEntries.groupBy { it.token.contractAddress.lowercase() }
+
+    return grouped.map { (_, entries) ->
+        val firstToken = entries.first().token
+
+        val totalBalance = entries.fold(BigDecimal.ZERO) { acc, entry ->
+            val rawBalance = BigDecimal.parseString(entry.token.balance)
+            acc + rawBalance
+        }
+
+        val totalValueUsd = entries.fold(BigDecimal.ZERO) { acc, entry ->
+            acc + (entry.token.todaysValue ?: BigDecimal.ZERO)
+        }
+
+        val breakdown = entries.map { entry ->
+            val rawBalance = BigDecimal.parseString(entry.token.balance)
+            val balanceHuman = rawBalance.divide(
+                BigDecimal.TEN.pow(firstToken.contractDecimals.toInt()),
+                calculatingDecimalMode
+            )
+            val valueUsd = entry.token.todaysValue ?: BigDecimal.ZERO
+            val pct = if (totalBalance > BigDecimal.ZERO) {
+                rawBalance.divide(totalBalance, DecimalMode(10, RoundingMode.ROUND_HALF_CEILING))
+                    .floatValue(exactRequired = false)
+            } else {
+                0f
+            }
+            EVMTokenAccountBreakdown(
+                accountName = entry.accountName,
+                accountAddress = entry.accountAddress,
+                balance = balanceHuman,
+                valueUsd = valueUsd,
+                percentage = pct
+            )
+        }
+
+        val totalBalanceHuman = totalBalance.divide(
+            BigDecimal.TEN.pow(firstToken.contractDecimals.toInt()),
+            calculatingDecimalMode
+        )
+
+        EVMAggregatedToken(
+            contractAddress = firstToken.contractAddress,
+            contractSymbol = firstToken.contractSymbol,
+            contractName = firstToken.contractName,
+            logoUrl = firstToken.logoUrl,
+            contractDecimals = firstToken.contractDecimals,
+            totalBalance = totalBalanceHuman,
+            totalValueUsd = totalValueUsd,
+            priceChangePercentage24h = firstToken.priceChangePercentage24h,
+            currentPrice = firstToken.currentPrice,
+            isCoin = firstToken.isCoin,
+            accountBreakdown = breakdown
+        )
+    }
+}

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/model/EVMFilterOptions.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/model/EVMFilterOptions.kt
@@ -1,0 +1,17 @@
+package com.mangala.features.wallet.presentationv2.evm.model
+
+data class EVMFilterOptions(
+    val hideSmallBalances: Boolean = false,
+    val sortBy: EVMTokenSortBy = EVMTokenSortBy.VALUE,
+    val viewMode: EVMViewMode = EVMViewMode.SINGLE_ACCOUNT
+)
+
+enum class EVMTokenSortBy {
+    NAME,
+    VALUE
+}
+
+enum class EVMViewMode {
+    SINGLE_ACCOUNT,
+    ALL_ACCOUNTS
+}


### PR DESCRIPTION
- Implemented EVMFilterBottomSheet for filter/sort options
- Added filter options: hide small balances (<$1), sort by name/value
- Added view mode toggle: single account vs all accounts (aggregated)