### PR TITLE
feat(security): block screenshots and screen recording on recovery phrase screens

### DIFF
--- a/common/ui/src/androidMain/kotlin/com/mangala/wallet/ui/SecureScreen.android.kt
+++ b/common/ui/src/androidMain/kotlin/com/mangala/wallet/ui/SecureScreen.android.kt
@@ -1,0 +1,35 @@
+package com.mangala.wallet.ui
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Traverses the [ContextWrapper] chain to find the underlying [Activity].
+ * In Compose, [LocalContext] may be a [ContextWrapper] rather than the [Activity] directly,
+ * so a simple `as? Activity` cast returns null and FLAG_SECURE would never be applied.
+ */
+private fun Context.findActivity(): Activity? {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    return null
+}
+
+@Composable
+actual fun SecureScreen(content: @Composable () -> Unit) {
+    val activity = LocalContext.current.findActivity()
+    DisposableEffect(Unit) {
+        activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        onDispose {
+            activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+    content()
+}

--- a/common/ui/src/commonMain/kotlin/com/mangala/wallet/ui/SecureScreen.kt
+++ b/common/ui/src/commonMain/kotlin/com/mangala/wallet/ui/SecureScreen.kt
@@ -1,0 +1,23 @@
+package com.mangala.wallet.ui
+
+import androidx.compose.runtime.Composable
+
+/**
+ * A composable wrapper that prevents screenshots and screen recordings of sensitive content.
+ *
+ * - Android: applies [android.view.WindowManager.LayoutParams.FLAG_SECURE] to the Activity window
+ *   for the duration the composable is in the composition, blocking both screenshots and system
+ *   screen recordings.
+ * - iOS: observes [platform.UIKit.UIScreenCapturedDidChangeNotification] and renders a full-screen
+ *   privacy overlay whenever the screen is being captured/recorded.
+ * - Desktop: no-op (no OS-level screenshot blocking available via Compose).
+ *
+ * Usage: wrap any sensitive screen content inside [SecureScreen]:
+ * ```kotlin
+ * SecureScreen {
+ *     // sensitive content here
+ * }
+ * ```
+ */
+@Composable
+expect fun SecureScreen(content: @Composable () -> Unit)

--- a/common/ui/src/desktopMain/kotlin/com/mangala/wallet/ui/SecureScreen.desktop.kt
+++ b/common/ui/src/desktopMain/kotlin/com/mangala/wallet/ui/SecureScreen.desktop.kt
@@ -1,0 +1,9 @@
+package com.mangala.wallet.ui
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun SecureScreen(content: @Composable () -> Unit) {
+    // No-op on desktop — no OS-level screenshot blocking available via Compose
+    content()
+}

--- a/common/ui/src/iosMain/kotlin/com/mangala/wallet/ui/SecureScreen.ios.kt
+++ b/common/ui/src/iosMain/kotlin/com/mangala/wallet/ui/SecureScreen.ios.kt
@@ -1,0 +1,60 @@
+package com.mangala.wallet.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.sp
+import platform.Foundation.NSNotificationCenter
+import platform.UIKit.UIScreen
+import platform.UIKit.UIScreenCapturedDidChangeNotification
+
+@Composable
+actual fun SecureScreen(content: @Composable () -> Unit) {
+    var isCaptured by remember { mutableStateOf(UIScreen.mainScreen.isCaptured()) }
+
+    DisposableEffect(Unit) {
+        val observer = NSNotificationCenter.defaultCenter.addObserverForName(
+            name = UIScreenCapturedDidChangeNotification,
+            `object` = UIScreen.mainScreen,
+            queue = null,
+            usingBlock = { _ ->
+                isCaptured = UIScreen.mainScreen.isCaptured()
+            }
+        )
+        onDispose {
+            NSNotificationCenter.defaultCenter.removeObserver(observer)
+        }
+    }
+
+    Box {
+        content()
+        if (isCaptured) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "Screen recording is\nnot allowed for security",
+                    color = Color.White,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}

--- a/core/wallet/src/commonMain/kotlin/com/mangala/wallet/wallet/presentation/backup/ShowRecoveryPhraseScreen.kt
+++ b/core/wallet/src/commonMain/kotlin/com/mangala/wallet/wallet/presentation/backup/ShowRecoveryPhraseScreen.kt
@@ -31,6 +31,7 @@ import com.mangala.wallet.common.mokoresources.icons.MangalaWalletPack
 import com.mangala.wallet.common.mokoresources.icons.mangalawalletpack.ArrowLeft
 import com.mangala.wallet.common.mokoresources.icons.mangalawalletpack.Copy
 import com.mangala.wallet.mokoresources.MR
+import com.mangala.wallet.ui.SecureScreen
 import com.mangala.wallet.ui.component.OnboardingButton
 import com.mangala.wallet.ui.component.OnboardingGradientBackground
 import com.mangala.wallet.ui.utils.collectAsStateMultiplatform
@@ -80,7 +81,8 @@ class ShowRecoveryPhraseScreen(
             }
         }
 
-        OnboardingGradientBackground(
+        SecureScreen {
+            OnboardingGradientBackground(
             circleBackgroundEnabled = true,
             afterBackgroundModifier = Modifier.navigationBarsPadding().imePadding()
         ) {
@@ -229,6 +231,7 @@ class ShowRecoveryPhraseScreen(
                 )
             }
         }
+        } // SecureScreen
     }
 
     override val isBottomBarVisible: Boolean = false

--- a/core/wallet/src/commonMain/kotlin/com/mangala/wallet/wallet/presentation/backup/VerifyRecoveryPhraseScreen.kt
+++ b/core/wallet/src/commonMain/kotlin/com/mangala/wallet/wallet/presentation/backup/VerifyRecoveryPhraseScreen.kt
@@ -25,6 +25,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import com.mangala.wallet.common.mokoresources.font.getInterFontFamily
 import com.mangala.wallet.common.mokoresources.icons.MangalaWalletPack
 import com.mangala.wallet.common.mokoresources.icons.mangalawalletpack.ArrowLeft
+import com.mangala.wallet.ui.SecureScreen
 import com.mangala.wallet.ui.SharedScreen
 import com.mangala.wallet.ui.component.OnboardingButton
 import com.mangala.wallet.ui.component.OnboardingGradientBackground
@@ -51,21 +52,23 @@ class VerifyRecoveryPhraseScreen : BaseScreen<ShowRecoveryPhraseScreenModel>() {
         val backupWalletDoneScreen = rememberScreen(SharedScreen.BackupWalletDoneScreen)
         val uiState by screenModel.uiState.collectAsStateMultiplatform()
 
-        if (uiState.recoveryPhrase.isNotEmpty() && uiState.verificationPositions.size == 3) {
-            val words = uiState.recoveryPhrase
-            val words2 = remember(words) { BIP39_WORDLIST_ENGLISH.filterNot { it in words } }
+        SecureScreen {
+            if (uiState.recoveryPhrase.isNotEmpty() && uiState.verificationPositions.size == 3) {
+                val words = uiState.recoveryPhrase
+                val words2 = remember(words) { BIP39_WORDLIST_ENGLISH.filterNot { it in words } }
 
-            VerifyPhraseContent(
-                words = words,
-                wrongWords = words2,
-                verificationPositions = uiState.verificationPositions,
-                onComplete = {
-                    navigator.push(backupWalletDoneScreen)
-                },
-                onBack = {
-                    navigator.pop()
-                }
-            )
+                VerifyPhraseContent(
+                    words = words,
+                    wrongWords = words2,
+                    verificationPositions = uiState.verificationPositions,
+                    onComplete = {
+                        navigator.push(backupWalletDoneScreen)
+                    },
+                    onBack = {
+                        navigator.pop()
+                    }
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Issue: https://github.com/MangalaLabs/mangala-wallet/issues/26 

Add SecureScreen composable (expect/actual) to prevent sensitive seed phrase content from being captured:

- [x] Android: applies FLAG_SECURE via ContextWrapper-aware Activity lookup
- [x] iOS: observes UIScreenCapturedDidChangeNotification and renders a full-screen privacy overlay when isCaptured() is true
- [x] Desktop: no-op pass-through

 Apply SecureScreen to ShowRecoveryPhraseScreen and VerifyRecoveryPhraseScreen.

https://github.com/user-attachments/assets/caf10c30-836a-487b-b4d6-ca50da8fa117

