### PR TITLE
refactor(security): centralize SecureScreen via BaseScreen + fix critical bugs

### DIFF
--- a/common/ui/src/androidMain/kotlin/com/mangala/wallet/ui/SecureScreen.android.kt
+++ b/common/ui/src/androidMain/kotlin/com/mangala/wallet/ui/SecureScreen.android.kt
@@ -7,11 +7,23 @@ import android.view.WindowManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalContext
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Process-level reference counter for FLAG_SECURE.
+ *
+ * Multiple [SecureScreen] composables can be active simultaneously (e.g., during
+ * Voyager navigation transitions where both the outgoing and incoming screens are
+ * composed). Using a counter ensures the flag is only added on the first entry and
+ * only removed when the last instance leaves the composition — preventing the
+ * "sibling clears sibling's protection" defect.
+ */
+private val secureScreenCount = AtomicInteger(0)
 
 /**
  * Traverses the [ContextWrapper] chain to find the underlying [Activity].
- * In Compose, [LocalContext] may be a [ContextWrapper] rather than the [Activity] directly,
- * so a simple `as? Activity` cast returns null and FLAG_SECURE would never be applied.
+ * In Compose, [LocalContext] may be a [ContextWrapper] rather than the [Activity]
+ * directly, so a simple `as? Activity` cast returns null silently.
  */
 private fun Context.findActivity(): Activity? {
     var context = this
@@ -25,11 +37,17 @@ private fun Context.findActivity(): Activity? {
 @Composable
 actual fun SecureScreen(content: @Composable () -> Unit) {
     val activity = LocalContext.current.findActivity()
-    DisposableEffect(Unit) {
-        activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+
+    DisposableEffect(activity) {
+        if (secureScreenCount.incrementAndGet() == 1) {
+            activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
         onDispose {
-            activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            if (secureScreenCount.decrementAndGet() == 0) {
+                activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            }
         }
     }
+
     content()
 }

--- a/common/ui/src/commonMain/kotlin/com/mangala/wallet/ui/utils/screenmodel/BaseScreen.kt
+++ b/common/ui/src/commonMain/kotlin/com/mangala/wallet/ui/utils/screenmodel/BaseScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import cafe.adriel.voyager.core.lifecycle.LifecycleEffect
 import cafe.adriel.voyager.core.screen.Screen
 import com.mangala.wallet.ui.LocalBottomNavigationVisibility
+import com.mangala.wallet.ui.SecureScreen
 import com.mangala.wallet.utils.analytics.MangalaAnalytics
 import kotlin.jvm.Transient
 
@@ -17,6 +18,22 @@ abstract class BaseScreen<T : BaseScreenModel>: Screen {
 
     open val isBottomBarVisible: Boolean = true
 
+    /**
+     * Per-screen opt-in flag for screenshot / screen-recording protection.
+     *
+     * Override to `true` to protect this screen regardless of [SecureScreenConfig].
+     * [SecureScreenConfig.secureScreenClassNames] is always checked as well — either
+     * this flag OR the registry entry being present is sufficient to enable protection.
+     *
+     * Example:
+     * ```kotlin
+     * class MyScreen : BaseScreen<MyScreenModel>() {
+     *     override val isSecure = true
+     * }
+     * ```
+     */
+    open val isSecure: Boolean = false
+
     abstract val screenName: String
     abstract val screenClassName: String
 
@@ -26,7 +43,14 @@ abstract class BaseScreen<T : BaseScreenModel>: Screen {
 
         LocalBottomNavigationVisibility.current.value = isBottomBarVisible
 
-        ScreenContent(screenModel)
+        val shouldSecure = isSecure || SecureScreenConfig.isSecure(screenClassName)
+        if (shouldSecure) {
+            SecureScreen {
+                ScreenContent(screenModel)
+            }
+        } else {
+            ScreenContent(screenModel)
+        }
 
         LifecycleEffect(
             onStarted = {

--- a/common/ui/src/commonMain/kotlin/com/mangala/wallet/ui/utils/screenmodel/SecureScreenConfig.kt
+++ b/common/ui/src/commonMain/kotlin/com/mangala/wallet/ui/utils/screenmodel/SecureScreenConfig.kt
@@ -1,0 +1,59 @@
+package com.mangala.wallet.ui.utils.screenmodel
+
+/**
+ * Centralized registry of screen class names that require screenshot and screen-recording
+ * protection via [SecureScreen].
+ *
+ * ## How to protect a screen
+ *
+ * ### Option A — Registry (recommended for bulk / configurable control)
+ * Add the screen's `simpleName` to [secureScreenClassNames]:
+ * ```kotlin
+ * object SecureScreenConfig {
+ *     val secureScreenClassNames: Set<String> = setOf(
+ *         "ShowRecoveryPhraseScreen",
+ *         "MyNewSensitiveScreen",   // ← add here
+ *     )
+ * }
+ * ```
+ * No changes to the screen file are needed.
+ *
+ * ### Option B — Per-screen flag (for one-off overrides)
+ * Override [BaseScreen.isSecure] directly in the screen class:
+ * ```kotlin
+ * class MyScreen : BaseScreen<MyScreenModel>() {
+ *     override val isSecure = true
+ * }
+ * ```
+ *
+ * Both options are checked by [BaseScreen.Content]; either one being `true` enables protection.
+ *
+ * ## Turning off protection for a screen
+ * - Registry: remove the class name from [secureScreenClassNames].
+ * - Flag: set `override val isSecure = false` (or remove the override).
+ */
+object SecureScreenConfig {
+
+    /**
+     * Set of screen [simpleName]s that must have screenshot / screen-recording protection.
+     * Checked at composition time by [BaseScreen].
+     */
+    val secureScreenClassNames: Set<String> = setOf(
+        // ── Wallet backup flow ──────────────────────────────────────────────
+        "ShowRecoveryPhraseScreen",
+        "VerifyRecoveryPhraseScreen",
+
+        // ── Antelope private-key backup ─────────────────────────────────────
+        "BackupAntelopeAccountScreen",
+        "BackupAntelopePrivateKeyScreen",
+
+        // ── PIN entry / setup ───────────────────────────────────────────────
+        "UnlockPinScreen",
+        "UnlockPinScreenV2",
+        "SetupPinScreen",
+    )
+
+    /** Returns `true` if the given [screenClassName] is in the protected registry. */
+    fun isSecure(screenClassName: String): Boolean =
+        screenClassName in secureScreenClassNames
+}

--- a/common/ui/src/iosMain/kotlin/com/mangala/wallet/ui/SecureScreen.ios.kt
+++ b/common/ui/src/iosMain/kotlin/com/mangala/wallet/ui/SecureScreen.ios.kt
@@ -38,7 +38,9 @@ actual fun SecureScreen(content: @Composable () -> Unit) {
         }
     }
 
-    Box {
+    // fillMaxSize ensures the privacy overlay always covers the entire screen,
+    // not just the bounds of content() which may be smaller than the display.
+    Box(modifier = Modifier.fillMaxSize()) {
         content()
         if (isCaptured) {
             Box(

--- a/core/wallet/src/commonMain/kotlin/com/mangala/wallet/wallet/presentation/backup/ShowRecoveryPhraseScreen.kt
+++ b/core/wallet/src/commonMain/kotlin/com/mangala/wallet/wallet/presentation/backup/ShowRecoveryPhraseScreen.kt
@@ -31,7 +31,6 @@ import com.mangala.wallet.common.mokoresources.icons.MangalaWalletPack
 import com.mangala.wallet.common.mokoresources.icons.mangalawalletpack.ArrowLeft
 import com.mangala.wallet.common.mokoresources.icons.mangalawalletpack.Copy
 import com.mangala.wallet.mokoresources.MR
-import com.mangala.wallet.ui.SecureScreen
 import com.mangala.wallet.ui.component.OnboardingButton
 import com.mangala.wallet.ui.component.OnboardingGradientBackground
 import com.mangala.wallet.ui.utils.collectAsStateMultiplatform
@@ -81,8 +80,7 @@ class ShowRecoveryPhraseScreen(
             }
         }
 
-        SecureScreen {
-            OnboardingGradientBackground(
+        OnboardingGradientBackground(
             circleBackgroundEnabled = true,
             afterBackgroundModifier = Modifier.navigationBarsPadding().imePadding()
         ) {
@@ -231,7 +229,6 @@ class ShowRecoveryPhraseScreen(
                 )
             }
         }
-        } // SecureScreen
     }
 
     override val isBottomBarVisible: Boolean = false

--- a/core/wallet/src/commonMain/kotlin/com/mangala/wallet/wallet/presentation/backup/VerifyRecoveryPhraseScreen.kt
+++ b/core/wallet/src/commonMain/kotlin/com/mangala/wallet/wallet/presentation/backup/VerifyRecoveryPhraseScreen.kt
@@ -25,7 +25,6 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import com.mangala.wallet.common.mokoresources.font.getInterFontFamily
 import com.mangala.wallet.common.mokoresources.icons.MangalaWalletPack
 import com.mangala.wallet.common.mokoresources.icons.mangalawalletpack.ArrowLeft
-import com.mangala.wallet.ui.SecureScreen
 import com.mangala.wallet.ui.SharedScreen
 import com.mangala.wallet.ui.component.OnboardingButton
 import com.mangala.wallet.ui.component.OnboardingGradientBackground
@@ -52,23 +51,21 @@ class VerifyRecoveryPhraseScreen : BaseScreen<ShowRecoveryPhraseScreenModel>() {
         val backupWalletDoneScreen = rememberScreen(SharedScreen.BackupWalletDoneScreen)
         val uiState by screenModel.uiState.collectAsStateMultiplatform()
 
-        SecureScreen {
-            if (uiState.recoveryPhrase.isNotEmpty() && uiState.verificationPositions.size == 3) {
-                val words = uiState.recoveryPhrase
-                val words2 = remember(words) { BIP39_WORDLIST_ENGLISH.filterNot { it in words } }
+        if (uiState.recoveryPhrase.isNotEmpty() && uiState.verificationPositions.size == 3) {
+            val words = uiState.recoveryPhrase
+            val words2 = remember(words) { BIP39_WORDLIST_ENGLISH.filterNot { it in words } }
 
-                VerifyPhraseContent(
-                    words = words,
-                    wrongWords = words2,
-                    verificationPositions = uiState.verificationPositions,
-                    onComplete = {
-                        navigator.push(backupWalletDoneScreen)
-                    },
-                    onBack = {
-                        navigator.pop()
-                    }
-                )
-            }
+            VerifyPhraseContent(
+                words = words,
+                wrongWords = words2,
+                verificationPositions = uiState.verificationPositions,
+                onComplete = {
+                    navigator.push(backupWalletDoneScreen)
+                },
+                onBack = {
+                    navigator.pop()
+                }
+            )
         }
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: SecureScreen protection now applied via SecureScreenConfig registry and BaseScreen.isSecure flag instead of manual wrapping.

  - Add SecureScreenConfig registry for centralized screen protection control
  - Refactor BaseScreen to auto-apply SecureScreen based on registry or isSecure flag
  - Remove manual SecureScreen wrappers from ShowRecoveryPhraseScreen and VerifyRecoveryPhraseScreen
  - Fix CRITICAL: FLAG_SECURE reference counting bug (AtomicInteger) preventing sibling screens from stripping protection
  - Fix HIGH: iOS outer Box missing fillMaxSize causing partial overlay coverage
  - Fix MEDIUM: DisposableEffect key changed from Unit to activity for semantic correctness

  Benefits:
  - Easy to protect new screens: add 1 line to SecureScreenConfig or override isSecure
  - Easy to toggle protection: edit registry or flip boolean flag
  - Centralized visibility: all protected screens listed in one file
  - Prevents reference-counting bug where navigating between secure screens could remove FLAG_SECURE