### PR TITLE
refactor(wallet): migrate EVM components to design system and fix account selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ google-services.json
 /build-cache
 GoogleService-Info.plist
 output-metadata.json
+.omc

--- a/common/ui/src/commonMain/kotlin/com/mangala/wallet/ui/WalletThemeV2.kt
+++ b/common/ui/src/commonMain/kotlin/com/mangala/wallet/ui/WalletThemeV2.kt
@@ -15,6 +15,7 @@ object WalletThemeV2 {
         val secondaryBackground = Color(0xFF1A1A1A)
         val cardBackground = Color(0xFF1D263E)
         val cardBorder = Color.White.copy(alpha = 0.05f)
+        val searchFieldBorder = Color.White.copy(alpha = 0.1f)
         val divider = Color.White.copy(alpha = 0.03f)
 
         // Text colors

--- a/common/ui/src/commonMain/kotlin/com/mangala/wallet/ui/WalletThemeV2.kt
+++ b/common/ui/src/commonMain/kotlin/com/mangala/wallet/ui/WalletThemeV2.kt
@@ -14,6 +14,8 @@ object WalletThemeV2 {
         val primaryBackground = Color(0xFF0A0E1A)
         val secondaryBackground = Color(0xFF1A1A1A)
         val cardBackground = Color(0xFF1D263E)
+        val cardBorder = Color.White.copy(alpha = 0.05f)
+        val divider = Color.White.copy(alpha = 0.03f)
 
         // Text colors
         val primaryText = Color(0xFFF1F5F9)

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletScreenModel.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletScreenModel.kt
@@ -60,13 +60,30 @@ class EVMWalletScreenModel(
 
     private var loadPortfolioJob: Job? = null
 
-    // Resolved synchronously so it's available before any coroutine runs
-    private var activeWalletId: String? = getSelectedWalletUseCase()?.id
+    /**
+     * Tracks the currently selected wallet ID for account index resolution.
+     * Stored in UiState to avoid thread-safety issues with a bare var.
+     * Updated by [observeWalletSelection] and read by [resolveAccountIndex].
+     */
+    private val activeWalletId: String?
+        get() = _uiState.value.activeWalletId
 
     init {
+        initActiveWalletId()
         observeBalanceVisibility()
         observeNetworkAndLoadPortfolio()
         observeWalletSelection()
+    }
+
+    /**
+     * Loads the initial active wallet ID asynchronously to avoid blocking the
+     * UI thread with a synchronous SQLDelight query during ScreenModel construction.
+     */
+    private fun initActiveWalletId() {
+        screenModelScope.launch {
+            val walletId = getSelectedWalletUseCase.invokeFlow().first()?.id
+            _uiState.update { it.copy(activeWalletId = walletId) }
+        }
     }
 
     private fun observeBalanceVisibility() {
@@ -107,7 +124,7 @@ class EVMWalletScreenModel(
                 .distinctUntilChanged()
                 .collectLatest { walletId ->
                     val previousWalletId = activeWalletId
-                    activeWalletId = walletId
+                    _uiState.update { it.copy(activeWalletId = walletId) }
 
                     if (previousWalletId != null && walletId != null && walletId != previousWalletId) {
                         selectFirstAccountOfWallet(walletId)
@@ -116,15 +133,23 @@ class EVMWalletScreenModel(
         }
     }
 
+    /**
+     * Selects the first account belonging to [walletId] in the current account list.
+     *
+     * If accounts haven't loaded yet (empty list), this is a no-op — [resolveAccountIndex]
+     * will handle the correct selection when accounts arrive, using [activeWalletId].
+     *
+     * If [walletId] has no matching accounts (e.g., the wallet was just imported but has no
+     * EVM accounts on the current network), falls back to index 0 so the UI doesn't show
+     * a stale account from the previous wallet.
+     */
     private fun selectFirstAccountOfWallet(walletId: String) {
         _uiState.update { state ->
             val accounts = state.accounts
             if (accounts.isEmpty()) return@update state
 
             val targetIndex = accounts.indexOfFirst { it.walletId == walletId }
-            if (targetIndex < 0) return@update state
-
-            state.copy(selectedAccountIndex = targetIndex)
+            state.copy(selectedAccountIndex = if (targetIndex >= 0) targetIndex else 0)
         }
     }
 

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletScreenModel.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletScreenModel.kt
@@ -1,10 +1,8 @@
 package com.mangala.features.wallet.presentationv2.evm
 
 import cafe.adriel.voyager.core.model.screenModelScope
-import com.mangala.features.wallet.presentationv2.evm.model.EVMFilterOptions
-import com.mangala.features.wallet.presentationv2.evm.model.EVMViewMode
-import com.mangala.wallet.model.blockchain.NetworkType
 import com.mangala.features.wallet.presentationv2.core.base.BaseWalletViewModel
+import com.mangala.features.wallet.presentationv2.evm.model.EVMFilterOptions
 import com.mangala.wallet.domain.currency.usecases.GetCurrentCurrencyCodeUseCase
 import com.mangala.wallet.domain.datastore.usecases.GetBalanceVisibleStatusUseCase
 import com.mangala.wallet.domain.datastore.usecases.GetSelectedNetworkUseCase
@@ -12,8 +10,10 @@ import com.mangala.wallet.domain.datastore.usecases.SaveBalanceVisibleStatusUseC
 import com.mangala.wallet.domain.datastore.usecases.SaveSelectedNetworkUseCase
 import com.mangala.wallet.domain.portfolio.model.AccountPortfolio
 import com.mangala.wallet.domain.portfolio.usecases.GetAllWalletsPortfolioUseCase
+import com.mangala.wallet.domain.wallet.usecases.GetSelectedWalletUseCase
 import com.mangala.wallet.features.chains.evmcompatible.model.Address
 import com.mangala.wallet.model.blockchain.BlockchainNetworkData
+import com.mangala.wallet.model.blockchain.NetworkType
 import com.mangala.wallet.model.currency.Currency
 import com.mangala.wallet.model.util.Resource
 import com.mangala.wallet.qrcode.domain.model.QrCodeData
@@ -26,7 +26,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -38,6 +40,7 @@ class EVMWalletScreenModel(
     private val saveBalanceVisibleStatusUseCase: SaveBalanceVisibleStatusUseCase,
     private val saveSelectedNetworkUseCase: SaveSelectedNetworkUseCase,
     private val parseQRCodeResultUseCase: ParseQRCodeResultUseCase,
+    private val getSelectedWalletUseCase: GetSelectedWalletUseCase,
     private val clipboardFactory: ClipboardFactory,
     private val shareFactory: ShareFactory,
     private val buildEnvironmentProvider: BuildEnvironmentProvider,
@@ -57,9 +60,13 @@ class EVMWalletScreenModel(
 
     private var loadPortfolioJob: Job? = null
 
+    // Resolved synchronously so it's available before any coroutine runs
+    private var activeWalletId: String? = getSelectedWalletUseCase()?.id
+
     init {
         observeBalanceVisibility()
         observeNetworkAndLoadPortfolio()
+        observeWalletSelection()
     }
 
     private fun observeBalanceVisibility() {
@@ -93,6 +100,34 @@ class EVMWalletScreenModel(
         }
     }
 
+    private fun observeWalletSelection() {
+        screenModelScope.launch {
+            getSelectedWalletUseCase.invokeFlow()
+                .map { it?.id }
+                .distinctUntilChanged()
+                .collectLatest { walletId ->
+                    val previousWalletId = activeWalletId
+                    activeWalletId = walletId
+
+                    if (previousWalletId != null && walletId != null && walletId != previousWalletId) {
+                        selectFirstAccountOfWallet(walletId)
+                    }
+                }
+        }
+    }
+
+    private fun selectFirstAccountOfWallet(walletId: String) {
+        _uiState.update { state ->
+            val accounts = state.accounts
+            if (accounts.isEmpty()) return@update state
+
+            val targetIndex = accounts.indexOfFirst { it.walletId == walletId }
+            if (targetIndex < 0) return@update state
+
+            state.copy(selectedAccountIndex = targetIndex)
+        }
+    }
+
     private suspend fun loadPortfolio(forceReload: Boolean, network: BlockchainNetworkData) {
         val currencyCode = getCurrentCurrencyCodeUseCase()
         val currencySymbol = Currency.valueOf(currencyCode).symbol
@@ -103,17 +138,11 @@ class EVMWalletScreenModel(
 
             val portfolioData = resource.data ?: return@collect
 
-            val currentSelectedIndex = _uiState.value.selectedAccountIndex
-            val validatedSelectedIndex = if (portfolioData.accounts.isEmpty()) {
-                0
-            } else {
-                currentSelectedIndex.coerceIn(0, portfolioData.accounts.lastIndex)
-            }
+            val validatedSelectedIndex = resolveAccountIndex(portfolioData.accounts)
 
-            val accountInfos = portfolioData.accounts.mapIndexed { index, accountPortfolio ->
+            val accountInfos = portfolioData.accounts.map { accountPortfolio ->
                 mapToAccountInfo(
                     accountPortfolio = accountPortfolio,
-                    isActive = index == validatedSelectedIndex,
                     isBalanceVisible = balanceVisible,
                     currencySymbol = currencySymbol
                 )
@@ -135,9 +164,34 @@ class EVMWalletScreenModel(
         }
     }
 
+    /**
+     * Determines which account index to select.
+     *
+     * - First load (accounts empty): pick the first account of the selected wallet.
+     * - Subsequent loads (refresh): keep current selection, clamped to valid range.
+     */
+    private fun resolveAccountIndex(loadedAccounts: List<AccountPortfolio>): Int {
+        if (loadedAccounts.isEmpty()) return 0
+
+        val currentAccounts = _uiState.value.accounts
+        val currentSelectedIndex = _uiState.value.selectedAccountIndex
+
+        // First load – select the first account belonging to the active wallet
+        if (currentAccounts.isEmpty()) {
+            val walletId = activeWalletId
+            if (walletId != null) {
+                val walletIndex = loadedAccounts.indexOfFirst { it.walletId == walletId }
+                if (walletIndex >= 0) return walletIndex
+            }
+            return 0
+        }
+
+        // Subsequent loads – preserve user's selection
+        return currentSelectedIndex.coerceIn(0, loadedAccounts.lastIndex)
+    }
+
     private fun mapToAccountInfo(
         accountPortfolio: AccountPortfolio,
-        isActive: Boolean,
         isBalanceVisible: Boolean,
         currencySymbol: String
     ): EVMAccountInfo {
@@ -147,7 +201,6 @@ class EVMWalletScreenModel(
             address = Address(accountPortfolio.address).eip55,
             walletId = accountPortfolio.walletId,
             balances = accountPortfolio.balances,
-            isActive = isActive,
             isBalanceVisible = isBalanceVisible,
             currencySymbol = currencySymbol,
             totalValueUsd = accountPortfolio.totalValueUsd,
@@ -190,13 +243,7 @@ class EVMWalletScreenModel(
 
     fun onAccountSelected(accountIndex: Int) {
         _uiState.update { state ->
-            val updatedAccounts = state.accounts.mapIndexed { index, account ->
-                account.copy(isActive = index == accountIndex)
-            }
-            state.copy(
-                accounts = updatedAccounts,
-                selectedAccountIndex = accountIndex
-            )
+            state.copy(selectedAccountIndex = accountIndex)
         }
     }
 

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletUiState.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletUiState.kt
@@ -162,7 +162,6 @@ data class EVMAccountInfo(
     val address: String,
     val walletId: String = "",
     val balances: List<TokenBalanceModel>? = null,
-    val isActive: Boolean = false,
     val isBalanceVisible: Boolean = true,
     val currencySymbol: String = "$",
     // Pre-calculated values from UseCase

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletUiState.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/EVMWalletUiState.kt
@@ -41,6 +41,8 @@ data class EVMWalletUiState(
     val searchQuery: String = "",
     // Filter state
     val filterOptions: EVMFilterOptions = EVMFilterOptions(),
+    // Internal: tracks which wallet is selected for account index resolution
+    val activeWalletId: String? = null,
 ) {
     val hasWallet: Boolean = accounts.isNotEmpty() || isLoadingWallets
 

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/components/EVMFilterBottomSheet.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/components/EVMFilterBottomSheet.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -25,17 +26,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.mangala.features.wallet.presentationv2.evm.model.EVMFilterOptions
 import com.mangala.features.wallet.presentationv2.evm.model.EVMTokenSortBy
 import com.mangala.features.wallet.presentationv2.evm.model.EVMViewMode
-import com.mangala.wallet.common.mokoresources.font.getInterFontFamily
 import com.mangala.wallet.mokoresources.MR
 import com.mangala.wallet.ui.WalletThemeV2
+import com.mangala.wallet.ui.theme.MangalaTypography
+import com.mangala.wallet.ui.theme.mangalaColors
 import dev.icerock.moko.resources.compose.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -49,11 +49,13 @@ fun EVMFilterBottomSheet(
         skipPartiallyExpanded = true
     )
 
+    val colors = MaterialTheme.mangalaColors
+
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = bottomSheetState,
-        containerColor = WalletThemeV2.Colors.cardBackground,
-        contentColor = Color.White,
+        containerColor = colors.bgInnerCard,
+        contentColor = colors.textPrimary,
         dragHandle = {
             Box(
                 modifier = Modifier
@@ -61,7 +63,7 @@ fun EVMFilterBottomSheet(
                     .width(40.dp)
                     .height(4.dp)
                     .background(
-                        Color.White.copy(alpha = 0.3f),
+                        colors.textSecondary.copy(alpha = 0.3f),
                         RoundedCornerShape(2.dp)
                     )
             )
@@ -74,10 +76,8 @@ fun EVMFilterBottomSheet(
         ) {
             Text(
                 text = stringResource(MR.strings.label_filter_and_sort),
-                fontSize = 20.sp,
-                fontWeight = FontWeight.SemiBold,
-                color = WalletThemeV2.Colors.primaryText,
-                fontFamily = getInterFontFamily(),
+                style = MangalaTypography.Size17SemiBold(),
+                color = colors.textPrimary,
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)
             )
 
@@ -95,10 +95,8 @@ fun EVMFilterBottomSheet(
 
             Text(
                 text = stringResource(MR.strings.label_sort_by),
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Medium,
-                color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f),
-                fontFamily = getInterFontFamily(),
+                style = MangalaTypography.Size14SemiBold(),
+                color = colors.textSecondary,
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
             )
 
@@ -122,10 +120,8 @@ fun EVMFilterBottomSheet(
 
             Text(
                 text = stringResource(MR.strings.label_view_mode),
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Medium,
-                color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f),
-                fontFamily = getInterFontFamily(),
+                style = MangalaTypography.Size14SemiBold(),
+                color = colors.textSecondary,
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
             )
 
@@ -160,6 +156,8 @@ private fun EVMFilterToggleItem(
     isSelected: Boolean,
     onClick: () -> Unit
 ) {
+    val colors = MaterialTheme.mangalaColors
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -168,12 +166,7 @@ private fun EVMFilterToggleItem(
             .background(Color.Transparent)
             .border(
                 width = 1.dp,
-                brush = Brush.linearGradient(
-                    colors = listOf(
-                        Color(0xFF2A3E6C),
-                        Color(0xFF2A3E6C)
-                    )
-                ),
+                brush = SolidColor(colors.border),
                 shape = RoundedCornerShape(16.dp)
             )
             .clickable { onClick() }
@@ -187,10 +180,8 @@ private fun EVMFilterToggleItem(
         ) {
             Text(
                 text = title,
-                fontSize = 15.sp,
-                fontWeight = FontWeight.Medium,
-                color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f),
-                fontFamily = getInterFontFamily()
+                style = MangalaTypography.Size14Medium(),
+                color = colors.textSecondary
             )
 
             if (isSelected) {
@@ -219,6 +210,8 @@ private fun EVMFilterSelectableItem(
     isSelected: Boolean,
     onClick: () -> Unit
 ) {
+    val colors = MaterialTheme.mangalaColors
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -228,19 +221,9 @@ private fun EVMFilterSelectableItem(
             .border(
                 width = if (isSelected) 2.dp else 1.dp,
                 brush = if (isSelected) {
-                    Brush.linearGradient(
-                        colors = listOf(
-                            Color(0xFF3B90FF),
-                            Color(0xFFC27DFF)
-                        )
-                    )
+                    colors.borderHighlight
                 } else {
-                    Brush.linearGradient(
-                        colors = listOf(
-                            Color(0xFF2A3E6C),
-                            Color(0xFF2A3E6C)
-                        )
-                    )
+                    SolidColor(colors.border)
                 },
                 shape = RoundedCornerShape(16.dp)
             )
@@ -255,12 +238,8 @@ private fun EVMFilterSelectableItem(
         ) {
             Text(
                 text = title,
-                fontSize = 15.sp,
-                fontWeight = FontWeight.Medium,
-                color = WalletThemeV2.Colors.primaryText.copy(
-                    alpha = if (isSelected) 0.95f else 0.8f
-                ),
-                fontFamily = getInterFontFamily()
+                style = MangalaTypography.Size14Medium(),
+                color = if (isSelected) colors.textPrimary else colors.textSecondary
             )
 
             if (isSelected) {

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/components/EVMTokenListSection.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/components/EVMTokenListSection.kt
@@ -45,15 +45,12 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import com.mangala.features.wallet.presentationv2.antelope.components.TokenLogo
 import com.mangala.features.wallet.presentationv2.evm.model.EVMAggregatedToken
 import com.mangala.features.wallet.presentationv2.evm.model.EVMTokenAccountBreakdown
-import com.mangala.wallet.common.mokoresources.font.getInterFontFamily
 import com.mangala.wallet.common.mokoresources.icons.MangalaWalletPack
 import com.mangala.wallet.common.mokoresources.icons.mangalawalletpack.Filter
 import com.mangala.wallet.common.mokoresources.icons.mangalawalletpack.Search
@@ -65,6 +62,7 @@ import com.mangala.wallet.ui.HIDDEN_BALANCE_STRING
 import com.mangala.wallet.ui.WalletThemeV2
 import com.mangala.wallet.ui.imageloader.ImageSource
 import com.mangala.wallet.ui.placeholder.mangalaWalletPlaceholder
+import com.mangala.wallet.ui.theme.MangalaTypography
 import com.mangala.wallet.utils.ext.formatFiat
 import dev.icerock.moko.resources.compose.stringResource
 
@@ -74,7 +72,7 @@ private fun Modifier.tokenListCard(): Modifier = this
     .background(WalletThemeV2.Colors.cardBackground)
     .border(
         width = 1.dp,
-        color = Color.White.copy(alpha = 0.05f),
+        color = WalletThemeV2.Colors.cardBorder,
         shape = RoundedCornerShape(16.dp)
     )
 
@@ -85,7 +83,7 @@ private fun TokenListDivider() {
             .fillMaxWidth()
             .height(1.dp)
             .padding(horizontal = WalletThemeV2.Dimensions.paddingLarge)
-            .background(Color.White.copy(alpha = 0.03f))
+            .background(WalletThemeV2.Colors.divider)
     )
 }
 
@@ -192,10 +190,8 @@ private fun TokenListHeader(
     ) {
         Text(
             text = if (isAllAccountsView) stringResource(MR.strings.label_portfolio) else tokensLabel,
-            fontSize = 16.sp,
-            fontWeight = FontWeight.Medium,
-            color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f),
-            fontFamily = getInterFontFamily()
+            style = MangalaTypography.Size14SemiBold(),
+            color = WalletThemeV2.Colors.primaryText
         )
 
         Row(
@@ -254,9 +250,8 @@ private fun TokenSearchField(
         placeholder = {
             Text(
                 text = placeholderText,
-                color = WalletThemeV2.Colors.secondaryText.copy(alpha = 0.6f),
-                fontSize = 14.sp,
-                fontFamily = getInterFontFamily()
+                style = MangalaTypography.Size14Regular(),
+                color = WalletThemeV2.Colors.secondaryText.copy(alpha = 0.6f)
             )
         },
         leadingIcon = {
@@ -286,7 +281,7 @@ private fun TokenSearchField(
             textColor = WalletThemeV2.Colors.primaryText,
             backgroundColor = WalletThemeV2.Colors.cardBackground.copy(alpha = 0.5f),
             focusedBorderColor = WalletThemeV2.Colors.evmAccent.copy(alpha = 0.8f),
-            unfocusedBorderColor = Color.White.copy(alpha = 0.1f),
+            unfocusedBorderColor = WalletThemeV2.Colors.cardBorder,
             cursorColor = WalletThemeV2.Colors.evmAccent
         ),
         modifier = Modifier
@@ -403,25 +398,21 @@ private fun EVMAggregatedTokenItem(
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = token.contractSymbol,
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Medium,
-                        color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.9f),
-                        fontFamily = getInterFontFamily()
+                        style = MangalaTypography.Size14Medium(),
+                        color = WalletThemeV2.Colors.primaryText
                     )
 
                     Text(
                         text = token.contractName,
-                        fontSize = 12.sp,
+                        style = MangalaTypography.Size12Regular(),
                         color = WalletThemeV2.Colors.secondaryText,
-                        fontFamily = getInterFontFamily(),
                         maxLines = 1
                     )
 
                     Text(
                         text = label24h,
-                        fontSize = 10.sp,
-                        color = WalletThemeV2.Colors.tertiaryText,
-                        fontFamily = getInterFontFamily()
+                        style = MangalaTypography.Size10Regular(),
+                        color = WalletThemeV2.Colors.tertiaryText
                     )
                 }
 
@@ -429,25 +420,21 @@ private fun EVMAggregatedTokenItem(
                     Text(
                         text = if (isBalanceHidden) HIDDEN_BALANCE_STRING
                         else token.totalBalance.scale(4).toStringExpanded(),
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Medium,
-                        color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.9f),
-                        fontFamily = getInterFontFamily()
+                        style = MangalaTypography.Size14Medium(),
+                        color = WalletThemeV2.Colors.primaryText
                     )
 
                     Text(
                         text = if (isBalanceHidden) HIDDEN_BALANCE_STRING
                         else token.totalValueUsd.formatFiat(currencySymbol, decimalPlaces = 2),
-                        fontSize = 12.sp,
-                        color = WalletThemeV2.Colors.secondaryText,
-                        fontFamily = getInterFontFamily()
+                        style = MangalaTypography.Size12Regular(),
+                        color = WalletThemeV2.Colors.secondaryText
                     )
 
                     Text(
                         text = formatPnlPercentage(pnlPercentage, isBalanceHidden),
-                        fontSize = 10.sp,
-                        color = if (isBalanceHidden) WalletThemeV2.Colors.secondaryText else pnlColor,
-                        fontFamily = getInterFontFamily()
+                        style = MangalaTypography.Size10Regular(),
+                        color = if (isBalanceHidden) WalletThemeV2.Colors.secondaryText else pnlColor
                     )
                 }
             }
@@ -469,10 +456,8 @@ private fun EVMAggregatedTokenItem(
             ) {
                 Text(
                     text = stringResource(MR.strings.label_allocation),
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.Medium,
+                    style = MangalaTypography.Size10Medium(),
                     color = WalletThemeV2.Colors.tertiaryText,
-                    fontFamily = getInterFontFamily(),
                     modifier = Modifier.padding(bottom = 6.dp)
                 )
 
@@ -537,10 +522,8 @@ private fun AccountAllocationRow(
             }
             Text(
                 text = percentageText,
-                fontSize = 8.sp,
-                fontWeight = FontWeight.Medium,
-                color = indicatorColor,
-                fontFamily = getInterFontFamily()
+                style = MangalaTypography.Size8SemiBold(),
+                color = indicatorColor
             )
         }
 
@@ -548,9 +531,8 @@ private fun AccountAllocationRow(
 
         Text(
             text = breakdown.accountName,
-            fontSize = 12.sp,
+            style = MangalaTypography.Size12Regular(),
             color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f),
-            fontFamily = getInterFontFamily(),
             modifier = Modifier.weight(1f)
         )
 
@@ -558,17 +540,15 @@ private fun AccountAllocationRow(
             Text(
                 text = if (isBalanceHidden) HIDDEN_BALANCE_STRING
                 else breakdown.balance.scale(4).toStringExpanded(),
-                fontSize = 12.sp,
-                color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f),
-                fontFamily = getInterFontFamily()
+                style = MangalaTypography.Size12Regular(),
+                color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.8f)
             )
 
             Text(
                 text = if (isBalanceHidden) HIDDEN_BALANCE_STRING
                 else breakdown.valueUsd.formatFiat(currencySymbol, decimalPlaces = 2),
-                fontSize = 10.sp,
-                color = WalletThemeV2.Colors.secondaryText,
-                fontFamily = getInterFontFamily()
+                style = MangalaTypography.Size10Regular(),
+                color = WalletThemeV2.Colors.secondaryText
             )
         }
     }
@@ -631,49 +611,41 @@ private fun EVMTokenItem(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = token.contractSymbol,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Medium,
-                    color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.9f),
-                    fontFamily = getInterFontFamily()
+                    style = MangalaTypography.Size14Medium(),
+                    color = WalletThemeV2.Colors.primaryText
                 )
 
                 Text(
                     text = token.contractName,
-                    fontSize = 12.sp,
+                    style = MangalaTypography.Size12Regular(),
                     color = WalletThemeV2.Colors.secondaryText,
-                    fontFamily = getInterFontFamily(),
                     maxLines = 1
                 )
 
                 Text(
                     text = label24h,
-                    fontSize = 10.sp,
-                    color = WalletThemeV2.Colors.tertiaryText,
-                    fontFamily = getInterFontFamily()
+                    style = MangalaTypography.Size10Regular(),
+                    color = WalletThemeV2.Colors.tertiaryText
                 )
             }
 
             Column(horizontalAlignment = Alignment.End) {
                 Text(
                     text = if (isBalanceHidden) HIDDEN_BALANCE_STRING else token.formattedBalanceForHuman(),
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Medium,
-                    color = WalletThemeV2.Colors.primaryText.copy(alpha = 0.9f),
-                    fontFamily = getInterFontFamily()
+                    style = MangalaTypography.Size14Medium(),
+                    color = WalletThemeV2.Colors.primaryText
                 )
 
                 Text(
                     text = if (isBalanceHidden) HIDDEN_BALANCE_STRING else token.formattedValue(currencySymbol),
-                    fontSize = 12.sp,
-                    color = WalletThemeV2.Colors.secondaryText,
-                    fontFamily = getInterFontFamily()
+                    style = MangalaTypography.Size12Regular(),
+                    color = WalletThemeV2.Colors.secondaryText
                 )
 
                 Text(
                     text = formatPnlPercentage(pnlPercentage, isBalanceHidden),
-                    fontSize = 10.sp,
-                    color = if (isBalanceHidden) WalletThemeV2.Colors.secondaryText else pnlColor,
-                    fontFamily = getInterFontFamily()
+                    style = MangalaTypography.Size10Regular(),
+                    color = if (isBalanceHidden) WalletThemeV2.Colors.secondaryText else pnlColor
                 )
             }
         }
@@ -773,9 +745,8 @@ private fun EmptyTokenState(
     ) {
         Text(
             text = message,
-            fontSize = 14.sp,
-            color = WalletThemeV2.Colors.secondaryText,
-            fontFamily = getInterFontFamily()
+            style = MangalaTypography.Size14Regular(),
+            color = WalletThemeV2.Colors.secondaryText
         )
     }
 }

--- a/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/components/EVMTokenListSection.kt
+++ b/features/wallet_pro/src/commonMain/kotlin/com/mangala/features/wallet/presentationv2/evm/components/EVMTokenListSection.kt
@@ -66,6 +66,8 @@ import com.mangala.wallet.ui.theme.MangalaTypography
 import com.mangala.wallet.utils.ext.formatFiat
 import dev.icerock.moko.resources.compose.stringResource
 
+// TODO: Migrate WalletThemeV2.Colors references to MaterialTheme.mangalaColors
+//  for design system consistency with EVMFilterBottomSheet (see PR #54 review).
 private fun Modifier.tokenListCard(): Modifier = this
     .fillMaxWidth()
     .clip(RoundedCornerShape(16.dp))
@@ -281,7 +283,7 @@ private fun TokenSearchField(
             textColor = WalletThemeV2.Colors.primaryText,
             backgroundColor = WalletThemeV2.Colors.cardBackground.copy(alpha = 0.5f),
             focusedBorderColor = WalletThemeV2.Colors.evmAccent.copy(alpha = 0.8f),
-            unfocusedBorderColor = WalletThemeV2.Colors.cardBorder,
+            unfocusedBorderColor = WalletThemeV2.Colors.searchFieldBorder,
             cursorColor = WalletThemeV2.Colors.evmAccent
         ),
         modifier = Modifier


### PR DESCRIPTION


Replace hardcoded colors and manual typography in EVMFilterBottomSheet with MangalaColors and MangalaTypography. Extract Color.White magic values in EVMTokenListSection to WalletThemeV2 tokens (cardBorder, divider). Observe wallet selection from settings via GetSelectedWalletUseCase to auto-select the first account of the active wallet instead of defaulting to index 0. Remove unused isActive field from EVMAccountInfo.